### PR TITLE
Programmatic API for creating services

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Fuzz test your REST API calls.
   + [Ignorable API calls](#ignorable-api-calls)
 * [Expectations](#expectations)
 * [Initializing Mocks](#initializing-mocks)
+* [Faker API](#faker-api)
 * [Runner](#runner)
 * [OpenAPI](#openapi)
 * [Tutorials](#tutorials)
@@ -369,6 +370,67 @@ github.state((req, schema) =>
 ```
 
 The unmock [documentation](https://www.unmock.io/docs/setting-state) contains more information about initializing the state.
+
+## Faker API
+
+`UnmockFaker` class provides a lower-level API for working with mocks. You can create a new `UnmockFaker` via `unmock.faker()`:
+
+```ts
+const unmock, { Service, ISerializedRequest} = require("unmock");
+// import unmock from "unmock";  // ES6
+
+const faker = unmock.faker();
+```
+
+To use the faker for mocking, you need to add services. The first option is to use the `nock` method:
+
+```ts
+faker
+  .nock("http://petstore.swagger.io", "petstore")
+  .get("/v1/pets")
+  .reply(200, { foo: u.string() });
+```
+
+Alternatively, you can create a service from OpenAPI specification with `Service.fromOpenAPI`:
+
+```ts
+const { Service } = require("unmock");
+
+const schema: OpenAPIObject = ...; // Load OpenAPIObject
+const petstoreService = Service.fromOpenAPI({ schema, name: "petstore" })
+
+// Add service to `faker`
+faker.add(petstoreService);
+```
+
+You can then also modify the state of the petstore service via `state` property:
+
+```ts
+const { transform } = require("unmock");
+// Service should always return code 200
+petstore.state(transform.withCodes(200));
+```
+
+Once you have added a service, you can use `faker.generate` method to create a mock for any `Request` object:
+
+```ts
+const { UnmockRequest, UnmockResponse } = require("unmock");
+
+const req: UnmockRequest = {
+  host: "petstore.swagger.io",
+  protocol: "http",
+  method: "get",
+  path: "/v1/pets",
+  pathname: "/v1/pets",
+  headers: {},
+  query: {},
+}
+
+const res: UnmockResponse = faker.generate(req);
+
+// Access res.statusCode, res.headers, res.body, etc.
+expect(res.statusCode).toBe(200);
+```
 
 ## Runner
 

--- a/packages/unmock-core/src/__tests__/faker.test.ts
+++ b/packages/unmock-core/src/__tests__/faker.test.ts
@@ -1,15 +1,61 @@
-import { u } from "..";
+import { transform, u } from "..";
 import UnmockFaker from "../faker";
+import { Service } from "../service";
 import { ServiceStore } from "../service/serviceStore";
+import { PetStoreSchema } from "./utils";
 
 const serviceStore = new ServiceStore([]);
 const faker = new UnmockFaker({ serviceStore });
+
+const countServices = (uFaker: UnmockFaker) =>
+  Object.keys(uFaker.services).length;
 
 const expectNServices = (expectedLength: number) =>
   expect(Object.keys(faker.services).length).toEqual(expectedLength);
 
 describe("UnmockFaker", () => {
-  beforeEach(() => serviceStore.removeAll());
+  beforeEach(() => faker.purge());
+
+  describe("purge()", () => {
+    it("should remove a service", () => {
+      faker
+        .nock("https://foo.com")
+        .get("/foo")
+        .reply(200, { foo: u.string() });
+      expectNServices(1);
+
+      faker.purge();
+      expectNServices(0);
+    });
+  });
+
+  describe("Adding services with add()", () => {
+    const petstoreService = Service.fromOpenAPI({
+      schema: PetStoreSchema,
+      name: "petstore",
+    });
+    beforeEach(() => {
+      faker.purge();
+      faker.add(petstoreService);
+      petstoreService.state(transform.withCodes(200));
+    });
+    it("adds a service", () => {
+      expect(countServices(faker)).toBe(1);
+    });
+    it("mocks after a service is added", () => {
+      const res = faker.generate({
+        host: "petstore.swagger.io",
+        protocol: "http",
+        method: "get",
+        path: "/v1/pets",
+        pathname: "/v1/pets",
+        headers: {},
+        query: {},
+      });
+      expect(res).toHaveProperty("body");
+      expect(res.statusCode).toBe(200);
+    });
+  });
 
   describe("adding service with nock syntax", () => {
     it("adds a service", () => {

--- a/packages/unmock-core/src/__tests__/faker.test.ts
+++ b/packages/unmock-core/src/__tests__/faker.test.ts
@@ -1,6 +1,5 @@
-import { transform, u } from "..";
+import { Service, transform, u } from "..";
 import UnmockFaker from "../faker";
-import { Service } from "../service";
 import { ServiceStore } from "../service/serviceStore";
 import { PetStoreSchema } from "./utils";
 

--- a/packages/unmock-core/src/__tests__/runner.test.ts
+++ b/packages/unmock-core/src/__tests__/runner.test.ts
@@ -1,5 +1,5 @@
 import { buildFetch, Fetch } from "unmock-fetch";
-import { Service, transform, UnmockPackage } from "..";
+import { IService, transform, UnmockPackage } from "..";
 import { Backend } from "../backend";
 import { IInterceptorOptions } from "../interceptor";
 import { testServiceDefLoader } from "./utils";
@@ -26,7 +26,7 @@ const backend = new Backend({
 const unmock = new UnmockPackage(backend);
 
 describe("Runner loop", () => {
-  let petstore: Service;
+  let petstore: IService;
 
   beforeAll(() => {
     unmock.on();

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -13,6 +13,7 @@ import {
   IRandomNumberGenerator,
   randomNumberGenerator,
 } from "../random-number-generator";
+import { Service } from "../service";
 import { addFromNock, NockAPI, ServiceStore } from "../service/serviceStore";
 
 export interface IFakerOptions {
@@ -78,6 +79,14 @@ export default class UnmockFaker implements IFaker {
    */
   public get services(): ServiceStoreType {
     return (this.serviceStore && this.serviceStore.services) || {};
+  }
+
+  /**
+   * Add a new service to Faker.
+   * @param service Service instance.
+   */
+  public add(service: Service) {
+    this.serviceStore.add(service);
   }
 
   /**

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -96,6 +96,13 @@ export default class UnmockFaker implements IFaker {
     this.serviceStore.resetServices();
   }
 
+  /**
+   * Remove all services.
+   */
+  public purge() {
+    this.serviceStore.removeAll();
+  }
+
   private createResponseCreator(options?: IUnmockOptions): CreateResponse {
     return responseCreatorFactory({
       listeners: this.listeners,

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -14,6 +14,7 @@ export { sinon };
 export { u } from "./nock";
 export { transform, Addl, Arr } from "./generator-utils";
 export { IService } from "./service/interfaces";
+export { Service } from "./service";
 export { ServiceCore } from "./service/serviceCore";
 export { Backend, buildRequestHandler };
 export { typeUtils };

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -26,6 +26,7 @@ export {
 
 export interface IService {
   readonly spy: ServiceSpy;
+  readonly core: IServiceCore;
   reset(): void;
   state(...f: IStateTransformer[]): void;
 }

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -1,10 +1,17 @@
 import { OpenAPIObject } from "loas3/dist/generated/full";
 import { ISerializedRequest, IStateTransformer } from "../interfaces";
 import { IService, IServiceCore } from "./interfaces";
+import { ServiceCore } from "./serviceCore";
 import { ServiceSpy } from "./spy";
 
 export class Service implements IService {
+  public static fromOpenAPI(schema: OpenAPIObject, name: string): Service {
+    const core = new ServiceCore({ schema, name });
+    return new Service(core);
+  }
+
   public readonly spy: ServiceSpy;
+
   constructor(private readonly core: IServiceCore) {
     this.spy = core.spy;
   }

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -12,7 +12,7 @@ export class Service implements IService {
 
   public readonly spy: ServiceSpy;
 
-  constructor(private readonly core: IServiceCore) {
+  constructor(public readonly core: IServiceCore) {
     this.spy = core.spy;
   }
 

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -5,7 +5,17 @@ import { ServiceCore } from "./serviceCore";
 import { ServiceSpy } from "./spy";
 
 export class Service implements IService {
-  public static fromOpenAPI(schema: OpenAPIObject, name: string): Service {
+  /**
+   * Create a new service from OpenAPI schema.
+   * @param param0 OpenAPI schema and service name.
+   */
+  public static fromOpenAPI({
+    schema,
+    name,
+  }: {
+    schema: OpenAPIObject;
+    name: string;
+  }): Service {
     const core = new ServiceCore({ schema, name });
     return new Service(core);
   }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -82,8 +82,21 @@ export class ServiceStore {
     this.services = services;
   }
 
+  /**
+   * Add a new service to the store.
+   * @param service Service instance.
+   * @throws Error if a service with the same name already exists.
+   */
   public add(service: Service): void {
     const core = service.core;
+    const serviceName = service.core.name;
+
+    if (this.services.hasOwnProperty(serviceName)) {
+      throw Error(`Service with name ${serviceName} exists.`);
+    }
+
+    this.cores[serviceName] = core;
+    this.services[serviceName] = service;
   }
 
   /**

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -82,6 +82,10 @@ export class ServiceStore {
     this.services = services;
   }
 
+  public add(service: Service): void {
+    const core = service.core;
+  }
+
   /**
    * Add service to the store using `nock` syntax.
    * @param baseUrl Base URL. For example: "https://api.github.com"

--- a/packages/unmock-core/src/types.ts
+++ b/packages/unmock-core/src/types.ts
@@ -5,7 +5,4 @@ export {
   ISerializedResponse as UnmockResponse,
   ServiceStoreType as UnmockServices,
 } from "./interfaces";
-export {
-  IService as UnmockService,
-  IService as Service,
-} from "./service/interfaces";
+export { IService as UnmockService } from "./service/interfaces";


### PR DESCRIPTION
Fixes #367.
- Adds `Service.fromOpenAPI()`  builder
- Exposes `core` from `Service`, it just makes life hard to hide that
- Export `Service` from `unmock` instead of export `IService` as `Service`, it should not break anything as there's only one kind of implementation of `IService`

- [x]  Documentation updates