### PR TITLE
Add admin endpoint for managing services.

### DIFF
--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -90,6 +90,14 @@ export default class UnmockFaker implements IFaker {
   }
 
   /**
+   * Updates service to Faker. Overwrites existing service with the same name.
+   * @param service Service instance.
+   */
+  public update(service: Service) {
+    this.serviceStore.updateOrAddService(service);
+  }
+
+  /**
    * Reset the states of all services.
    */
   public reset() {

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -1,4 +1,4 @@
-import { OpenAPIObject } from "loas3/dist/generated/full";
+import { isOpenAPIObject, OpenAPIObject } from "loas3/dist/generated/full";
 import { ISerializedRequest, IStateTransformer } from "../interfaces";
 import { IService, IServiceCore } from "./interfaces";
 import { ServiceCore } from "./serviceCore";
@@ -18,6 +18,10 @@ export class Service implements IService {
   }): Service {
     const core = new ServiceCore({ schema, name });
     return new Service(core);
+  }
+
+  public static isOpenAPIObject(schema: any): schema is OpenAPIObject {
+    return isOpenAPIObject(schema);
   }
 
   public readonly spy: ServiceSpy;

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -88,12 +88,22 @@ export class ServiceStore {
    * @throws Error if a service with the same name already exists.
    */
   public add(service: Service): void {
-    const core = service.core;
     const serviceName = service.core.name;
 
-    if (this.services.hasOwnProperty(serviceName)) {
+    if (this.serviceExists(serviceName)) {
       throw Error(`Service with name ${serviceName} exists.`);
     }
+
+    this.updateOrAddService(service);
+  }
+
+  /**
+   * Update a service or add a new service if one with the given name does not exist.
+   * @param service Service instance.
+   */
+  public updateOrAddService(service: Service): void {
+    const core = service.core;
+    const serviceName = service.core.name;
 
     this.cores[serviceName] = core;
     this.services[serviceName] = service;
@@ -181,5 +191,9 @@ export class ServiceStore {
    */
   public resetServices() {
     Object.values(this.services).forEach(service => service.reset());
+  }
+
+  private serviceExists(name: string): boolean {
+    return Object.keys(this.services).includes(name);
   }
 }

--- a/packages/unmock-server/README.md
+++ b/packages/unmock-server/README.md
@@ -11,9 +11,9 @@ Unmock server mocks APIs using [unmock-js](https://github.com/Meeshkan/unmock-js
 
 ### `npm`
 
-The npm package ships with `unmock-server` binary that you can add either in project or globally.
+The npm package ships with `unmock-server` CLI that you can add either in project or globally.
 
-#### Install to a project
+#### Install in project
 
 ```bash
 npm install unmock-server

--- a/packages/unmock-server/README.md
+++ b/packages/unmock-server/README.md
@@ -1,12 +1,11 @@
 # unmock-server
 
 [![npm](https://img.shields.io/npm/v/unmock-server.svg)](https://www.npmjs.com/package/unmock-server)
-[![CircleCI](https://circleci.com/gh/unmock/unmock-js.svg?style=svg)](https://circleci.com/gh/unmock/unmock-js)
+[![CircleCI](https://circleci.com/gh/unmock/unmock-js.svg?style=svg)](https://circleci.com/gh/Meeshkan/unmock-js)
 [![codecov](https://codecov.io/gh/unmock/unmock-js/branch/dev/graph/badge.svg)](https://codecov.io/gh/unmock/unmock-js)
 [![Known Vulnerabilities](https://snyk.io/test/github/unmock/unmock-js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/unmock/unmock-js?targetFile=package.json)
 
-Unmock server mocks APIs using [unmock-js](https://github.com/unmock/unmock-js).
-
+Unmock server mocks APIs using [unmock-js](https://github.com/Meeshkan/unmock-js).
 
 ## Installation
 
@@ -59,13 +58,13 @@ Start `unmock-server` with `start` command:
 $ unmock-server start
 ```
 
-You need to add `npx` or `yarn` before the command depending on your installation method.
+You may need to add `npx` or `yarn` before the command depending on your installation method.
 
-Running `unmock-server start` starts
+The `start` command starts
 
-1. an admin server at port 8888 for managing services
-1. a proxy server at port 8008 for mocking requests
-1. a mock server at port 8000 (HTTP) and 8443 (HTTPS) for internally handling requests made to the proxy.
+1. admin server at port 8888 for managing services
+1. proxy server at port 8008 for mocking requests
+1. mock server at port 8000 (HTTP) and 8443 (HTTPS) for internally handling requests made to the proxy.
 
 ### Using the mock proxy
 
@@ -87,18 +86,31 @@ To use the proxy for mocking requests, you need to:
     > wget https://raw.githubusercontent.com/unmock/unmock-js/dev/packages/unmock-server/certs/ca.pem`
     > ```
     > You then need to add the mock server certificate to the list of trusted certificates.
-    > For `curl`: set environment variable
-    > - `SSL_CERT_FILE=ca.pem`
+    > For `curl`, set environment variable `SSL_CERT_FILE=ca.pem`
 
 #### Example calls with `cURL`
 
-- Request to proxy with HTTP: `http_proxy=http://localhost:8008 curl -i http://api.github.com/user/repos`
-- Request to proxy with HTTPS: `https_proxy=http://localhost:8008 SSL_CERT_FILE=ca.pem curl -i https://api.github.com/user/repos`
-- to mock server directly: `curl -i --header "X-Forwarded-Host: api.github.com" http://localhost:8000/user/repos`
+Request to proxy with HTTP: 
+
+```bash
+$ http_proxy=http://localhost:8008 curl -i http://api.github.com/user/repos
+```
+
+Request to proxy with HTTPS: 
+
+```bash
+$ https_proxy=http://localhost:8008 SSL_CERT_FILE=ca.pem curl -i https://api.github.com/user/repos
+```
+
+Request to mock server without using the proxy: 
+
+```bash
+$ curl -i --header "X-Forwarded-Host: api.github.com" http://localhost:8000/user/repos
+```
 
 ### Managing services
 
-You can manage services either via the admin API or via filesystem.
+You can manage services either via the admin REST API or through filesystem.
 
 #### Using the admin server
 
@@ -122,17 +134,13 @@ $ curl http://localhost:8888/services/my-service
 
 #### Using `__unmock__` folder
 
-Prepare `__unmock__` folder with [OpenAPI specifications](https://www.unmock.io/docs/openapi).
+At startup, `unmock-server` loads all services from `__unmock__` folder. For example, to mock `api.github.com`, you need to
 
-> To mock `api.github.com`:
-> 1. Prepare `__unmock__` folder:
-> > ```bash
-> > mkdir -p __unmock__/githubv3
-> > ```
-> 1. Put the GitHub OpenAPI specification to `__unmock__/githubv3`:
-> > ```bash
-> > wget https://raw.githubusercontent.com/unmock/DefinitelyMocked/master/services/githubv3/openapi.yaml -O __unmock__/githubv3/openapi.yaml`
-> > ```
+1. Prepare `__unmock__` folder: `mkdir -p __unmock__/githubv3`
+1. Add the GitHub OpenAPI specification to `__unmock__/githubv3`:
+> `wget https://raw.githubusercontent.com/unmock/DefinitelyMocked/master/services/githubv3/openapi.yaml -O __unmock__/githubv3/openapi.yaml`
+
+When `unmock-server` is started, it loads the GitHub API with name `githubv3`. For more detailed instructions, see the [Unmock documentation](https://www.unmock.io/docs/openapi).
 
 ## Docker
 

--- a/packages/unmock-server/README.md
+++ b/packages/unmock-server/README.md
@@ -1,7 +1,7 @@
 # unmock-server
 
 [![npm](https://img.shields.io/npm/v/unmock-server.svg)](https://www.npmjs.com/package/unmock-server)
-[![CircleCI](https://circleci.com/gh/unmock/unmock-js.svg?style=svg)](https://circleci.com/gh/Meeshkan/unmock-js)
+[![CircleCI](https://circleci.com/gh/Meeshkan/unmock-js.svg?style=svg)](https://circleci.com/gh/Meeshkan/unmock-js)
 [![codecov](https://codecov.io/gh/unmock/unmock-js/branch/dev/graph/badge.svg)](https://codecov.io/gh/unmock/unmock-js)
 [![Known Vulnerabilities](https://snyk.io/test/github/unmock/unmock-js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/unmock/unmock-js?targetFile=package.json)
 

--- a/packages/unmock-server/README.md
+++ b/packages/unmock-server/README.md
@@ -66,6 +66,12 @@ The `start` command starts
 1. proxy server at port 8008 for mocking requests
 1. mock server at port 8000 (HTTP) and 8443 (HTTPS) for internally handling requests made to the proxy.
 
+Stop `unmock-server` with `stop` command:
+
+```bash
+$ unmock-server stop
+```
+
 ### Using the mock proxy
 
 To use the proxy for mocking requests, you need to:

--- a/packages/unmock-server/README.md
+++ b/packages/unmock-server/README.md
@@ -62,7 +62,7 @@ You may need to add `npx` or `yarn` before the command depending on your install
 
 The `start` command starts
 
-1. admin server at port 8888 for managing services
+1. admin server at port 8888 (override with `UNMOCK_ADMIN_PORT` environment variable) for managing services
 1. proxy server at port 8008 for mocking requests
 1. mock server at port 8000 (HTTP) and 8443 (HTTPS) for internally handling requests made to the proxy.
 

--- a/packages/unmock-server/README.md
+++ b/packages/unmock-server/README.md
@@ -7,34 +7,6 @@
 
 Unmock server mocks APIs using [unmock-js](https://github.com/unmock/unmock-js).
 
-## How it works
-
-Unmock server consists of
-
-1. a proxy server at port 8008
-1. a mock server at port 8000 (HTTP) and 8443 (HTTPS)
-
-Once the server and proxy are running, you can use the proxy to mock an API. For that, you need to:
-
-1. Prepare specifications for your [services](https://www.unmock.io/docs/openapi) in `__unmock__` directory
-
-1. Start Unmock server and proxy (see below)
-
-1. Set your HTTP client to use the locally running proxy
-
-   >  `curl`: set environment variables
-   > - `http_proxy=http://localhost:8008`
-   > - `https_proxy=http://localhost:8008`
-   > - Other clients may expect `HTTP_PROXY` and `HTTPS_PROXY` environment variables instead
-
-1. Trust the certificates served by the mock proxy if using HTTPS:
-
-    > Fetch certificate:
-    > ```bas
-    > wget https://raw.githubusercontent.com/unmock/unmock-js/dev/packages/unmock-server/certs/ca.pem`
-    > ```
-    > For `curl`: set environment variable
-    > - `SSL_CERT_FILE=ca.pem`
 
 ## Installation
 
@@ -79,17 +51,76 @@ unmock-server --help
 1. Build TypeScript: `npm run compile`
 1. Invoke the CLI: `node packages/unmock-server/bin/run`
 
-## How to use it
+## Usage
 
-### 1. Prepare the certificate (HTTPS only)
-
-If mocking HTTPS server, fetch the Unmock certificate used for signing certificates:
+Start `unmock-server` with `start` command:
 
 ```bash
-wget https://raw.githubusercontent.com/unmock/unmock-js/dev/packages/unmock-server/certs/ca.pem
+$ unmock-server start
 ```
 
-### 2. Prepare services
+You need to add `npx` or `yarn` before the command depending on your installation method.
+
+Running `unmock-server start` starts
+
+1. an admin server at port 8888 for managing services
+1. a proxy server at port 8008 for mocking requests
+1. a mock server at port 8000 (HTTP) and 8443 (HTTPS) for internally handling requests made to the proxy.
+
+### Using the mock proxy
+
+To use the proxy for mocking requests, you need to:
+
+1. Define services you want to mock (see below)
+
+1. Set your HTTP client to use the locally running proxy
+
+   >  `curl`: set environment variables
+   > - `http_proxy=http://localhost:8008`
+   > - `https_proxy=http://localhost:8008`
+   > - Other clients may expect `HTTP_PROXY` and `HTTPS_PROXY` environment variables instead
+
+1. If mocking a server using HTTPS, you need to fetch the certificate served by the mock proxy:
+
+    > Fetch certificate:
+    > ```bas
+    > wget https://raw.githubusercontent.com/unmock/unmock-js/dev/packages/unmock-server/certs/ca.pem`
+    > ```
+    > You then need to add the mock server certificate to the list of trusted certificates.
+    > For `curl`: set environment variable
+    > - `SSL_CERT_FILE=ca.pem`
+
+#### Example calls with `cURL`
+
+- Request to proxy with HTTP: `http_proxy=http://localhost:8008 curl -i http://api.github.com/user/repos`
+- Request to proxy with HTTPS: `https_proxy=http://localhost:8008 SSL_CERT_FILE=ca.pem curl -i https://api.github.com/user/repos`
+- to mock server directly: `curl -i --header "X-Forwarded-Host: api.github.com" http://localhost:8000/user/repos`
+
+### Managing services
+
+You can manage services either via the admin API or via filesystem.
+
+#### Using the admin server
+
+Get all services:
+
+```bash
+$ curl http://localhost:8888/services
+```
+
+Post a new service with name `my-service`:
+
+```bash
+$ curl -X POST http://localhost:8888/services/my-service -H "Content-Type: application/json" --data "@/path/to/openapi.json"
+```
+
+Get a service description for service with name `my-service`:
+
+```bash
+$ curl http://localhost:8888/services/my-service
+```
+
+#### Using `__unmock__` folder
 
 Prepare `__unmock__` folder with [OpenAPI specifications](https://www.unmock.io/docs/openapi).
 
@@ -98,31 +129,21 @@ Prepare `__unmock__` folder with [OpenAPI specifications](https://www.unmock.io/
 > > ```bash
 > > mkdir -p __unmock__/githubv3
 > > ```
-> 1. Fetch OpenAPI specification:
+> 1. Put the GitHub OpenAPI specification to `__unmock__/githubv3`:
 > > ```bash
 > > wget https://raw.githubusercontent.com/unmock/DefinitelyMocked/master/services/githubv3/openapi.yaml -O __unmock__/githubv3/openapi.yaml`
 > > ```
-
-### Start server
-
-Start Unmock server and proxy:
-
-```bash
-unmock-server start
-```
-
-### Start making calls
-
-Make calls
-- to proxy with HTTP: `http_proxy=http://localhost:8008 curl -i http://api.github.com/user/repos`
-- to proxy with HTTPS: `https_proxy=http://localhost:8008 SSL_CERT_FILE=ca.pem curl -i https://api.github.com/user/repos`
-- to mock server directly: `curl -i --header "X-Forwarded-Host: api.github.com" http://localhost:8000/user/repos`
 
 ## Docker
 
 Unmock server can also be used via Docker. See documentation for the [unmock/unmock-server](https://hub.docker.com/r/unmock/unmock-server) Docker image.
 
 ## Development
+
+### Running the CLI
+
+1. Compile TypeScript by running `npm run compile` at the root of the monorepo
+1. Invoke [./bin/run](./bin/run) or [./bin/run.cmd](./bin/run.cmd).
 
 ### Creating new CA certificate
 

--- a/packages/unmock-server/package.json
+++ b/packages/unmock-server/package.json
@@ -28,6 +28,7 @@
     "@types/express": "^4.17.1",
     "@types/http-proxy": "^1.17.0",
     "@types/node-forge": "^0.8.6",
+    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "helmet": "^3.21.1",
     "http-proxy": "^1.18.0",

--- a/packages/unmock-server/src/admin.ts
+++ b/packages/unmock-server/src/admin.ts
@@ -1,0 +1,40 @@
+import express = require("express");
+// @ts-ignore
+import helmet = require("helmet");
+import * as http from "http";
+import { DEFAULT_ADMIN_PORT } from "./constants";
+
+const httpPort = process.env.UNMOCK_ADMIN_PORT
+  ? parseInt(process.env.UNMOCK_ADMIN_PORT, 10)
+  : DEFAULT_ADMIN_PORT;
+
+export const servicesRoute = (): express.Router => {
+  const router = express.Router();
+  return router;
+};
+
+export const buildAdminApp = () => {
+  const app = express();
+
+  app.use(helmet());
+  app.use("/services", servicesRoute());
+
+  return app;
+};
+
+export const startAdminServer = ({
+  app,
+  port,
+}: {
+  app: express.Express;
+  port?: number;
+}) => {
+  const portToListen = port || httpPort;
+  const httpServer = http.createServer(app);
+
+  httpServer.listen(portToListen, () => {
+    console.log(`Admin server starting on port ${portToListen}`); // tslint:disable-line
+  });
+
+  return httpServer;
+};

--- a/packages/unmock-server/src/admin.ts
+++ b/packages/unmock-server/src/admin.ts
@@ -1,23 +1,86 @@
+import * as bodyParser from "body-parser";
+import debug from "debug";
 import express = require("express");
 // @ts-ignore
 import helmet = require("helmet");
 import * as http from "http";
+import { Service, UnmockPackage } from "unmock-core";
 import { DEFAULT_ADMIN_PORT } from "./constants";
 
 const httpPort = process.env.UNMOCK_ADMIN_PORT
   ? parseInt(process.env.UNMOCK_ADMIN_PORT, 10)
   : DEFAULT_ADMIN_PORT;
 
-export const servicesRoute = (): express.Router => {
+const debugLog = debug("unmock-server:admin");
+
+const serviceExists = (unmock: UnmockPackage, name: string) => {
+  return Object.keys(unmock.services)
+    .map(service => service)
+    .includes(name);
+};
+
+const postServiceHandler = (unmock: UnmockPackage) => (
+  req: express.Request,
+  res: express.Response,
+) => {
+  const name = req.params.service;
+  const body = req.body;
+
+  if (!Service.isOpenAPIObject(body)) {
+    return res.status(400).send("Body not valid OpenAPI object");
+  }
+
+  const exists = serviceExists(unmock, name);
+
+  if (!exists) {
+    debugLog(`Creating new service ${name}`);
+    unmock.backend.faker.add(Service.fromOpenAPI({ schema: body, name }));
+  } else {
+    debugLog(`Service ${name} exists, updating`);
+    unmock.backend.faker.update(Service.fromOpenAPI({ schema: body, name }));
+  }
+
+  return res.sendStatus(200);
+};
+
+const getServiceHandler = (unmock: UnmockPackage) => (
+  req: express.Request,
+  res: express.Response,
+) => {
+  const name = req.params.service;
+
+  const exists = serviceExists(unmock, name);
+
+  if (!exists) {
+    return res.status(404).send(`Service with name: ${name} does not exist.`);
+  }
+
+  debugLog(`Service ${name} exists, updating`);
+  const schema = unmock.services[name].core.schema;
+
+  return res.status(200).send(schema);
+};
+
+export const servicesRoute = ({
+  unmock,
+}: {
+  unmock: UnmockPackage;
+}): express.Router => {
   const router = express.Router();
+
+  router.post("/:service", postServiceHandler(unmock));
+  router.get("/:service", getServiceHandler(unmock));
+
   return router;
 };
 
-export const buildAdminApp = () => {
+export const buildAdminApp = ({ unmock }: { unmock: UnmockPackage }) => {
   const app = express();
 
   app.use(helmet());
-  app.use("/services", servicesRoute());
+  app.use(bodyParser.json());
+
+  app.use("/services", servicesRoute({ unmock }));
 
   return app;
 };

--- a/packages/unmock-server/src/admin.ts
+++ b/packages/unmock-server/src/admin.ts
@@ -43,7 +43,7 @@ const postServiceHandler = (unmock: UnmockPackage) => (
   debugLog(`Service ${serviceName} exists, updating`);
   unmock.backend.faker.update(service);
 
-  return res.json({ message: `Service ${serviceName} updated` });
+  return res.json({ message: `Updated service ${serviceName}` });
 };
 
 const getServices = (unmock: UnmockPackage) => (
@@ -63,7 +63,7 @@ const getServiceHandler = (unmock: UnmockPackage) => (
   const exists = serviceExists(unmock, name);
 
   if (!exists) {
-    return res.status(404).send(`Service with name: ${name} does not exist.`);
+    return res.status(404).send(`Service ${name} does not exist.`);
   }
 
   debugLog(`Service ${name} exists, updating`);

--- a/packages/unmock-server/src/commands/start.ts
+++ b/packages/unmock-server/src/commands/start.ts
@@ -38,10 +38,10 @@ export default class Start extends Command {
   public async run() {
     debugLog("Starting.");
     const run = () => {
-      const { app } = buildApp();
+      const { app, unmock } = buildApp();
       const [httpServer, httpsServer] = startServer(app);
 
-      const adminApp = buildAdminApp();
+      const adminApp = buildAdminApp({ unmock });
       const adminHttpServer = startAdminServer({ app: adminApp });
 
       const proxyServer = startProxy();

--- a/packages/unmock-server/src/commands/start.ts
+++ b/packages/unmock-server/src/commands/start.ts
@@ -1,5 +1,6 @@
 import { Command, flags } from "@oclif/command";
 import debug from "debug";
+import { buildAdminApp, startAdminServer } from "../admin";
 import { deletePidFile, writePid } from "../pid";
 import { startProxy } from "../proxy";
 import { buildApp, startServer } from "../server";
@@ -39,6 +40,10 @@ export default class Start extends Command {
     const run = () => {
       const { app } = buildApp();
       const [httpServer, httpsServer] = startServer(app);
+
+      const adminApp = buildAdminApp();
+      const adminHttpServer = startAdminServer({ app: adminApp });
+
       const proxyServer = startProxy();
 
       debugLog("Writing PID to file for closing...");
@@ -49,6 +54,7 @@ export default class Start extends Command {
         httpServer.close();
         httpsServer.close();
         proxyServer.close();
+        adminHttpServer.close();
         debugLog("Servers closed.");
         deletePidFile();
       };

--- a/packages/unmock-server/src/constants.ts
+++ b/packages/unmock-server/src/constants.ts
@@ -1,3 +1,4 @@
 export const SERVER_HTTP_PORT = 8000;
 export const SERVER_HTTPS_PORT = 8443;
 export const PROXY_PORT = 8008;
+export const DEFAULT_ADMIN_PORT = 8888;


### PR DESCRIPTION
Adds the admin API, closes #376.

## Endpoints

Get all services:

```bash
$ curl http://localhost:8888/services
```

Post a new service with name `my-service`:

```bash
$ curl -X POST http://localhost:8888/services/my-service -H "Content-Type: application/json" --data "@/path/to/openapi.json"
```

Note that this doesn't yet accept YAML.

Get OpenAPI schema for service with name `my-service`:

```bash
$ curl http://localhost:8888/services/my-service
```

## TODO
- [ ]  Tests 😁 
- [ ]  Use something more modern instead of `express` like `koa` or `nest.js` 