### PR TITLE
Does not throw on broken format

### DIFF
--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -914,6 +914,9 @@ const generateMockFromTemplate = ({
   // disables this temporarily as it messes with user-defined min items
   // jsf.option("minItems", runnerConfiguration.minItems);
   // jsf.option("minLength", runnerConfiguration.minItems);
+  // some specs have invalid formats. we do not want this to fail - we
+  // still want a comprehensible result
+  jsf.option("failOnInvalidFormat", false);
   jsf.option("useDefaultValue", false);
   jsf.option("random", () => fakerOptions.randomNumberGenerator.get());
   const bodyAsJson = bodySchema ? jsf.generate(bodySchema) : undefined;

--- a/packages/unmock-node/src/__tests__/__unmock__/petstore/spec.yaml
+++ b/packages/unmock-node/src/__tests__/__unmock__/petstore/spec.yaml
@@ -109,6 +109,6 @@ components:
       properties:
         code:
           type: integer
-          format: int32
+          format: intentionally_broken_format
         message:
           type: string

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -11,6 +11,9 @@ describe("Loads services properly", () => {
   it("loads all paths in __unmock__", () => {
     const backend = new NodeBackend({ servicesDirectory });
     backend.services.slack.state((_, __) => __); // should pass
+    // we have intentionally set an incorrect format in petstore's yml file
+    // grep for `intentionally_broken_format`
+    // it should load anyway
     backend.services.petstore.state((_, __) => __); // should pass
     expect(() => backend.services.github.state((_, __) => __)).toThrow(
       "property 'state' of undefined",


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  https://github.com/unmock/unmock-js/blob/dev/CONTRIBUTING.md

  Have any questions? 
  Feel free to ask in this PR and one of our maintainers will be happy to help 🙌
-->

Fixes the fact that unmock cannot load a spec with a broken format.

## Description

Tells json schema faker not to throw if there is a broken format.

<!-- Write a brief description of the changes introduced by this PR -->

## How to test 

One of the `petstore` yml files has been modified to include a broken format.

<!-- What steps can we take to test that your code is working properly -->