### PR TITLE
Docs: Update runner guide to include unmock-jest-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,11 @@ expect(res.statusCode).toBe(200);
 
 ## Runner
 
-The [Unmock `runner`](packages/unmock-runner) wraps any test and runs that same test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+With the [Unmock `runner`](packages/unmock-runner), you can run any test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+
+### Default
+
+By default, the `runner` is set to run your test 20 times.
 
 ### Jest
 
@@ -447,7 +451,7 @@ npm install -D unmock-jest-runner
 yarn add unmock-jest-runner
 ```
 
-Once installed, it can be imported and used as a wrapper for your tests:
+Once installed, the `runner` can be imported as a default and used as a wrapper for your tests:
 
 ```js
 const runner = require("unmock-jest-runner").default;
@@ -462,7 +466,7 @@ test("my API always works as expected", runner(async () => {
 
 As of now, Jest is the only package we have available. 
 
-However, we're currently building out support for [Mocha]() and [Qunit](). You can follow the progress of those implementations in the corresponding issues.
+However, we're currently building out support for [Mocha](https://github.com/Meeshkan/unmock-js/issues/299) and [QUnit](https://github.com/Meeshkan/unmock-js/issues/300). You can follow the progress of those implementations in the corresponding issues.
 
 ## OpenAPI
 

--- a/README.md
+++ b/README.md
@@ -434,15 +434,35 @@ expect(res.statusCode).toBe(200);
 
 ## Runner
 
-The unmock runner runs the same test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+The [Unmock `runner`](packages/unmock-runner) wraps any test and runs that same test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+
+### Jest
+
+A Jest configuration for the `runner` is available through a separate [`unmock-jest-runner`](https://github.com/meeshkan/unmock-jest-runner) package. While the standard `unmock-runner` is available via NPM, you'll want to use the `unmock-jest-runner` when executing your tests to ensure proper error handling. 
+
+The `unmock-jest-runner` can be installed via NPM or Yarn:
+
+```
+npm install -D unmock-jest-runner
+yarn add unmock-jest-runner
+```
+
+Once installed, it can be imported and used as a wrapper for your tests:
 
 ```js
-const { runner } = "unmock";
+const runner = require("unmock-jest-runner").default;
+
 test("my API always works as expected", runner(async () => {
   const res = await myApiFunction();
   // some expectations
 }));
 ```
+
+### Other configurations
+
+As of now, Jest is the only package we have available. 
+
+However, we're currently building out support for [Mocha]() and [Qunit](). You can follow the progress of those implementations in the corresponding issues.
 
 ## OpenAPI
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ With the [Unmock `runner`](packages/unmock-runner), you can run any test multipl
 
 ### Default
 
-By default, the `runner` is set to run your test 20 times.
+By default, the `runner` is set to run your test 20 times. If you want to change this value, please refer to our docs on [changing the `runner` default](https://github.com/Meeshkan/unmock-js/blob/unmock-runner-docs/packages/unmock-runner/README.md#changing-the-default).
 
 ### Jest
 

--- a/packages/unmock-runner/README.md
+++ b/packages/unmock-runner/README.md
@@ -1,8 +1,10 @@
 # unmock-runner
 
-Core functions for the Unmock `runner`.
+With the Unmock `runner`, you can run any test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
 
-The Unmock `runner` wraps any test and runs that same test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+### Default
+
+By default, the `runner` is set to run your test 20 times.
 
 ### Jest
 
@@ -15,7 +17,7 @@ npm install -D unmock-jest-runner
 yarn add unmock-jest-runner
 ```
 
-Once installed, it can be imported and used as a wrapper for your tests:
+Once installed, the `runner` can be imported as a default and used as a wrapper for your tests:
 
 ```js
 const runner = require("unmock-jest-runner").default;
@@ -30,4 +32,4 @@ test("my API always works as expected", runner(async () => {
 
 As of now, Jest is the only package we have available. 
 
-However, we're currently building out support for [Mocha]() and [Qunit](). You can follow the progress of those implementations in the corresponding issues.
+However, we're currently building out support for [Mocha](https://github.com/Meeshkan/unmock-js/issues/299) and [QUnit](https://github.com/Meeshkan/unmock-js/issues/300). You can follow the progress of those implementations in the corresponding issues.

--- a/packages/unmock-runner/README.md
+++ b/packages/unmock-runner/README.md
@@ -1,5 +1,33 @@
 # unmock-runner
 
-Core functions for the Unmock runner.
+Core functions for the Unmock `runner`.
 
-<!-- TODO: After implementing separate NPM packages, update this documentation with description, defaults and examples -->
+The Unmock `runner` wraps any test and runs that same test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
+
+### Jest
+
+A Jest configuration for the `runner` is available through a separate [`unmock-jest-runner`](https://github.com/meeshkan/unmock-jest-runner) package. While the standard `unmock-runner` is available via NPM, you'll want to use the `unmock-jest-runner` when executing your tests to ensure proper error handling. 
+
+The `unmock-jest-runner` can be installed via NPM or Yarn:
+
+```
+npm install -D unmock-jest-runner
+yarn add unmock-jest-runner
+```
+
+Once installed, it can be imported and used as a wrapper for your tests:
+
+```js
+const runner = require("unmock-jest-runner").default;
+
+test("my API always works as expected", runner(async () => {
+  const res = await myApiFunction();
+  // some expectations
+}));
+```
+
+### Other configurations
+
+As of now, Jest is the only package we have available. 
+
+However, we're currently building out support for [Mocha]() and [Qunit](). You can follow the progress of those implementations in the corresponding issues.

--- a/packages/unmock-runner/README.md
+++ b/packages/unmock-runner/README.md
@@ -2,11 +2,29 @@
 
 With the Unmock `runner`, you can run any test multiple times with different potential outcomes from the API. All of your unmock tests should use the `runner` unless you are absolutely certain that the API response will be the same every time.
 
-### Default
+## Default
 
 By default, the `runner` is set to run your test 20 times.
 
-### Jest
+### Changing the default
+
+To change the number of times that your test will run, you need to pass a second argument to the `runner` function. This will be an object where you set the `maxLoop` value to another integer.
+
+```js
+// We don't set a value for maxLoop, so this test uses the default
+test("This test will run 20 times", runner(async () => {
+  const res = await myApiFunction();
+  // some expectations
+}));
+
+// Now we pass a second argument to the runner that sets the maxLoop to 100 
+test("This test will run 100 times", runner(async () => {
+  const res = await myApiFunction();
+  // some expectations
+}, { maxLoop: 100 }));
+```
+
+## Jest
 
 A Jest configuration for the `runner` is available through a separate [`unmock-jest-runner`](https://github.com/meeshkan/unmock-jest-runner) package. While the standard `unmock-runner` is available via NPM, you'll want to use the `unmock-jest-runner` when executing your tests to ensure proper error handling. 
 
@@ -22,13 +40,13 @@ Once installed, the `runner` can be imported as a default and used as a wrapper 
 ```js
 const runner = require("unmock-jest-runner").default;
 
-test("my API always works as expected", runner(async () => {
+test("My API always works as expected", runner(async () => {
   const res = await myApiFunction();
   // some expectations
 }));
 ```
 
-### Other configurations
+## Other configurations
 
 As of now, Jest is the only package we have available. 
 


### PR DESCRIPTION
Blocked by #391 

Added a description and some usage details to the root README and the README for the `unmock-runner` package.

Some questions still lingering:
- Is it possible to change the default?
- Do we need the same documentation on both READMEs or would it be better to have the full documentation within the `unmock-runner` and then give a shorter description with a link on the root README?

Related to https://github.com/Meeshkan/unmock-js/issues/299