### PR TITLE
Add unmock.mock to replace unmock.nock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const { runner, transform, u } = unmock;
 const { withCodes } = transform;
 
 unmock
-  .nock("https://zodiac.com", "zodiac")
+  .mock("https://zodiac.com", "zodiac")
   .get("/horoscope/{sign}") // 1
   .reply(200, {
     horoscope: u.string(), // 2
@@ -107,7 +107,7 @@ With unmock, you can (1) override a REST endpoint to provide (2) variable and (3
 The request hostname should be a string.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .get('/resource')
   .reply(200, u.integer())
 ```
@@ -115,7 +115,7 @@ unmock.nock('http://www.example.com')
 Unmock will then refer to the service as `example`. To specify the name of the service as `foo`, we would write.
 
 ```js
-unmock.nock('http://www.example.com', 'foo')
+unmock.mock('http://www.example.com', 'foo')
   .get('/resource')
   .reply(200, u.string())
 ```
@@ -131,7 +131,7 @@ unmock.default.associate('https://www2.example.com', 'foo')
 The request path should be a string, and you can use any [HTTP verb](#http-verbs). Wild-cards in the string should be enclosed in curly braces.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .get('/resource/{id}')
   .reply(200, u.string())
 ```
@@ -139,7 +139,7 @@ unmock.nock('http://www.example.com')
 Alternatively, you can use an array of path segments, where each segment is either a string, a string in curly-braces for an open parameter, or a key/value pair associating a name of a path parameter to a regex matching it.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .get(["users", /[0-9]+/, "status"]) // "/users/{id}/status"
   .reply(200, u.string())
 ```
@@ -151,7 +151,7 @@ You can specify the request body to be matched as the second argument to the `ge
 Here is an example of a post request that will only validate if it contains a token.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .post('/login', u.type({ token: u.string()}, {expires: u.integer()}))
   .reply(200, { id: u.string() })
 ```
@@ -167,7 +167,7 @@ Unmock automatically ignores query strings. However, it understands query string
 These parameters can be included as part of the path:
 
 ```js
-unmock.nock('http://example.com')
+unmock.mock('http://example.com')
   .get('/users?foo=bar')
   .reply(200)
 ```
@@ -175,7 +175,7 @@ unmock.nock('http://example.com')
 Instead of placing the entire URL, you can specify the query part as an object:
 
 ```js
-unmock.nock('http://example.com')
+unmock.mock('http://example.com')
   .get('/users')
   .query({ name:u.string(), surname: u.string() })
   .reply(200, { results: u.array({id: u.integer() }) })
@@ -186,7 +186,7 @@ unmock.nock('http://example.com')
 You can specify the request headers like this:
 
 ```js
-unmock.nock('http://www.example.com', {
+unmock.mock('http://www.example.com', {
   reqheaders: {
     authorization: 'Basic Auth',
   },
@@ -198,7 +198,7 @@ unmock.nock('http://www.example.com', {
 Or you can use a regular expression to check the header values.
 
 ```js
-const scope = nock('http://www.example.com', {
+unmock.mock('http://www.example.com', {
   reqheaders: {
     'X-My-Awesome-Header': /Awesome/i,
   },
@@ -214,7 +214,7 @@ Headers in unmock are always a partial match, meaning that additional headers ar
 You can specify the return status code for a path on the first argument of reply like this:
 
 ```js
-unmock.nock('http://myapp.iriscouch.com')
+unmock.mock('http://myapp.iriscouch.com')
   .get('/users/1')
   .reply(404)
 ```
@@ -222,7 +222,7 @@ unmock.nock('http://myapp.iriscouch.com')
 You can also specify the reply body as valid JSON, `json-schema-poet`, or any combination thereof.
 
 ```js
-unmock.nock('http://www.google.com')
+unmock.mock('http://www.google.com')
   .get('/')
   .reply(200, u.stringEnum(['Hello from Google!', 'Do no evil']))
 ```
@@ -230,7 +230,7 @@ unmock.nock('http://www.google.com')
 If you would like to transform any part of a constant reply (ie a fixture recorded from real API traffic) into a variable version of itself, use `u.fuzz`. This command infers the type of its input and produces output following the same schema.
 
 ```js
-unmock.nock('http://www.foo.com')
+unmock.mock('http://www.foo.com')
   .get('/')
   // produces { firstName: "a random string", lastName: "another random string" }
   .reply(200, u.fuzz({ firstName: "Bob", lastName: "Smith" }))
@@ -241,7 +241,7 @@ unmock.nock('http://www.foo.com')
 You can specify the reply headers like this:
 
 ```js
-unmock.nock('https://api.github.com')
+unmock.mock('https://api.github.com')
   .get('/repos/atom/atom/license')
   .reply(200, { license: 'MIT' }, { 'X-RateLimit-Remaining': u.integer() })
 ```
@@ -251,7 +251,7 @@ unmock.nock('https://api.github.com')
 You can chain behavior like this:
 
 ```js
-unmock. nock('http://myapp.iriscouch.com')
+unmock.mock('http://myapp.iriscouch.com')
   .get('/users/1')
   .reply(404)
   .post('/users', {
@@ -278,7 +278,7 @@ For ignorable API calls where you are passing through information but don't care
 
 ```js
 unmock
-  .nock("https://my-analytics-api.vendor.com)
+   .mock("https://my-analytics-api.vendor.com)
   .tldr();
 ```
 
@@ -382,11 +382,11 @@ const unmock, { Service, ISerializedRequest} = require("unmock");
 const faker = unmock.faker();
 ```
 
-To use the faker for mocking, you need to add services. The first option is to use the `nock` method:
+To use the faker for mocking, you need to add services. The first option is to use the `mock` method:
 
 ```ts
 faker
-  .nock("http://petstore.swagger.io", "petstore")
+  .mock("http://petstore.swagger.io", "petstore")
   .get("/v1/pets")
   .reply(200, { foo: u.string() });
 ```

--- a/packages/unmock-browser/src/index.ts
+++ b/packages/unmock-browser/src/index.ts
@@ -11,6 +11,6 @@ if (typeof Buffer === "undefined") {
 
 export const unmock = new UnmockPackage(new BrowserBackend());
 
-export const nock = unmock.nock.bind(unmock);
-
+export const nock = unmock.mock.bind(unmock);
+export const mock = unmock.mock.bind(unmock);
 export default unmock;

--- a/packages/unmock-cli/src/commands/init.starter.tmp.ts
+++ b/packages/unmock-cli/src/commands/init.starter.tmp.ts
@@ -32,7 +32,7 @@ signs = ['Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpi
 
 unmock
   .default
-  .nock("https://api.example.com/v1", "example")
+  .mock("https://api.example.com/v1", "example")
   .get("/users")
   .reply(200, {
     users: u.array({ // an array of arbitrary length

--- a/packages/unmock-core/src/__tests__/faker.test.ts
+++ b/packages/unmock-core/src/__tests__/faker.test.ts
@@ -18,7 +18,7 @@ describe("UnmockFaker", () => {
   describe("purge()", () => {
     it("should remove a service", () => {
       faker
-        .nock("https://foo.com")
+        .mock("https://foo.com")
         .get("/foo")
         .reply(200, { foo: u.string() });
       expectNServices(1);
@@ -59,14 +59,14 @@ describe("UnmockFaker", () => {
   describe("adding service with nock syntax", () => {
     it("adds a service", () => {
       faker
-        .nock("https://foo.com")
+        .mock("https://foo.com")
         .get("/foo")
         .reply(200, { foo: u.string() });
       expectNServices(1);
     });
     it("adds a service and allows faking it", () => {
       faker
-        .nock("https://foo.com")
+        .mock("https://foo.com")
         .get("/foo")
         .reply(200, { foo: u.string() });
       const res = faker.generate({

--- a/packages/unmock-core/src/__tests__/index.test.ts
+++ b/packages/unmock-core/src/__tests__/index.test.ts
@@ -31,7 +31,7 @@ const unmock = new UnmockPackage(backend);
 let foo: IService;
 beforeAll(() => {
   unmock
-    .nock("https://www.foo.com", "foo")
+    .mock("https://www.foo.com", "foo")
     .get("/hello")
     .reply(200, { foo: u.string() });
   foo = unmock.on().services.foo;

--- a/packages/unmock-core/src/__tests__/nock.test.ts
+++ b/packages/unmock-core/src/__tests__/nock.test.ts
@@ -15,7 +15,7 @@ describe("Tests dynamic path tests", () => {
   it("Adds a service", () => {
     expectNServices(0);
     unmock
-      .nock("https://foo.com")
+      .mock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
     expectNServices(1);
@@ -24,7 +24,7 @@ describe("Tests dynamic path tests", () => {
   it("should add a service when used with named export", () => {
     expectNServices(0);
     unmock
-      .nock("https://foo.com")
+      .mock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
     expectNServices(1);
@@ -33,7 +33,7 @@ describe("Tests dynamic path tests", () => {
   it("Adds a service and changes state", () => {
     expectNServices(0);
     unmock
-      .nock("https://foo.com")
+      .mock("https://foo.com")
       .get("foo") // slash is prepended automatically
       .reply(200, { foo: u.string() });
     expectNServices(1);
@@ -47,11 +47,11 @@ describe("Tests dynamic path tests", () => {
   it("Adds a service and updates it on consecutive calls", () => {
     expectNServices(0);
     unmock
-      .nock("https://foo.com")
+      .mock("https://foo.com")
       .get("foo") // slash is prepended automatically
       .reply(200, { foo: u.string("address.city") });
     unmock
-      .nock("https://foo.com")
+      .mock("https://foo.com")
       .post("/foo")
       .reply(201);
     expectNServices(1);
@@ -65,7 +65,7 @@ describe("Tests dynamic path tests", () => {
   it("Adds a named service", () => {
     expectNServices(0);
     unmock
-      .nock("https://abc.com", "foo")
+      .mock("https://abc.com", "foo")
       .get("abc") // slash is prepended automatically
       .reply(200, { foo: u.string() });
     expectNServices(1);
@@ -74,7 +74,7 @@ describe("Tests dynamic path tests", () => {
   it("Chains multiple endpoints", () => {
     expectNServices(0);
     unmock
-      .nock("https://abc.com", "foo")
+      .mock("https://abc.com", "foo")
       .get("abc") // slash is prepended automatically
       .reply(200, { foo: u.string() })
       .post("bar")
@@ -85,7 +85,7 @@ describe("Tests dynamic path tests", () => {
   it("Chains multiple endpoints in multiple calls", () => {
     expectNServices(0);
     const dynamicSpec = unmock
-      .nock("https://abc.com", "foo")
+      .mock("https://abc.com", "foo")
       .get("foo")
       .reply(200, { city: u.string("address.city") });
     dynamicSpec.get("foo").reply(404, { msg: u.string("address.city") });
@@ -95,15 +95,15 @@ describe("Tests dynamic path tests", () => {
   it("Allows using same name with multiple servers", () => {
     expectNServices(0);
     unmock
-      .nock("https://abc.com", "foo")
+      .mock("https://abc.com", "foo")
       .get("foo")
       .reply(200, { city: u.string("address.city") });
     unmock
-      .nock("https://def.com", "foo")
+      .mock("https://def.com", "foo")
       .get("foo")
       .reply(404, { msg: u.string("address.city") });
     unmock
-      .nock("https://abc.com", "foo")
+      .mock("https://abc.com", "foo")
       .get("foo")
       .reply(500);
     expect(getPrivateSchema("foo").servers).toEqual([
@@ -115,7 +115,7 @@ describe("Tests dynamic path tests", () => {
   it("Defines different responses on same endpoint and method", () => {
     expectNServices(0);
     unmock
-      .nock("https://foo.com", "foo")
+      .mock("https://foo.com", "foo")
       .get("bar")
       .reply(200, { msg: u.string() })
       .reply(404, { msg: "Page not found!" });
@@ -137,7 +137,7 @@ describe("Tests dynamic path tests", () => {
     it("Associates a service by url", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com")
+        .mock("https://www.foo.com")
         .get("")
         .reply(200);
       expect(unmock.services["www.foo.com"]).toBeDefined();
@@ -151,7 +151,7 @@ describe("Tests dynamic path tests", () => {
     it("Associates a url by name", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("")
         .reply(200);
       expect(unmock.services.foo).toBeDefined();
@@ -169,11 +169,11 @@ describe("Tests dynamic path tests", () => {
     it("A URL can be associated with multiple services", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("")
         .reply(200);
       unmock
-        .nock("https://www.bar.com", "bar")
+        .mock("https://www.bar.com", "bar")
         .get("")
         .reply(200);
       expect(unmock.services.foo).toBeDefined();
@@ -192,11 +192,11 @@ describe("Tests dynamic path tests", () => {
     it("A URL can be associated with multiple services and won't delete other services if they share name and URL", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("")
         .reply(200);
       unmock
-        .nock("https://www.bar.com")
+        .mock("https://www.bar.com")
         .get("")
         .reply(200);
       expect(unmock.services.foo).toBeDefined();
@@ -217,7 +217,7 @@ describe("Tests dynamic path tests", () => {
       unmock.associate("https://www.foo.com", "foo"); // empty service
       expectNServices(1);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("")
         .reply(200);
       expectNServices(1);
@@ -226,7 +226,7 @@ describe("Tests dynamic path tests", () => {
       expectNServices(2);
       // since a name is not given, it cannot be associated with previously declared www.bar.com.
       unmock
-        .nock("https://www.bar.com")
+        .mock("https://www.bar.com")
         .get("")
         .reply(200);
       expectNServices(3);
@@ -237,7 +237,7 @@ describe("Tests dynamic path tests", () => {
     it("An empty array of strings is equal to root path", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get([])
         .reply(200);
       expectNServices(1);
@@ -247,7 +247,7 @@ describe("Tests dynamic path tests", () => {
     it("An array of strings is equal to the string of its parts", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get(["foo", "foo", "foo"])
         .reply(200);
       expectNServices(1);
@@ -259,7 +259,7 @@ describe("Tests dynamic path tests", () => {
     it("A simple regex is added as a parameter with randomly generated name", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get(["foo", /\w+/, "bar"])
         .reply(200);
       expectNServices(1);
@@ -277,7 +277,7 @@ describe("Tests dynamic path tests", () => {
     it("A regex is added as a parameter given name", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get(["foo", ["baz", /\W+/], "bar"])
         .reply(200);
       expectNServices(1);
@@ -294,7 +294,7 @@ describe("Tests dynamic path tests", () => {
     it("Also handles multiple parameters", async () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get(["foo", ["baz", /\W+/], "bar", /\d+/, ["spam", /eggs/]])
         .reply(200);
       expectNServices(1);
@@ -314,7 +314,7 @@ describe("Tests dynamic path tests", () => {
     it("An empty query results in a viable spec", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", {}, "foo")
+        .mock("https://www.foo.com", {}, "foo")
         .get("/")
         .query({})
         .reply(200);
@@ -325,7 +325,7 @@ describe("Tests dynamic path tests", () => {
     it("A query is correctly propagated", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("/")
         .query({ foo: "bar" })
         .reply(200);
@@ -344,7 +344,7 @@ describe("Tests dynamic path tests", () => {
     it("A query in the path correctly propagated", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("/?q&m=1&") // include an empty query
         .reply(200);
       expectNServices(1);
@@ -372,7 +372,7 @@ describe("Tests dynamic path tests", () => {
     it("An empty request header results in a viable spec", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", {}, "foo")
+        .mock("https://www.foo.com", {}, "foo")
         .get("/")
         .reply(200);
       expectNServices(1);
@@ -382,7 +382,7 @@ describe("Tests dynamic path tests", () => {
     it("A request header is correctly propagated", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", { reqheaders: { hello: "world" } }, "foo")
+        .mock("https://www.foo.com", { reqheaders: { hello: "world" } }, "foo")
         .get("/")
         .reply(200);
       expectNServices(1);
@@ -402,7 +402,7 @@ describe("Tests dynamic path tests", () => {
   describe("tldr adds 9 levels of arbitrary paths to requests", () => {
     it("ignores unimportant stuff", () => {
       expectNServices(0);
-      unmock.nock("https://www.foo.com", "foo").tldr();
+      unmock.mock("https://www.foo.com", "foo").tldr();
       expectNServices(1);
       expect(Object.keys(getPrivateSchema("foo").paths).length).toEqual(9);
     });
@@ -412,7 +412,7 @@ describe("Tests dynamic path tests", () => {
     it("An empty reply header results in a viable spec", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("/")
         .reply(200, "", {});
       expectNServices(1);
@@ -422,7 +422,7 @@ describe("Tests dynamic path tests", () => {
     it("A reply header is correctly propagated", () => {
       expectNServices(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get("/")
         .reply(200, "", { hello: "world" });
       expectNServices(1);

--- a/packages/unmock-core/src/__tests__/spy-vs-spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy-vs-spy.test.ts
@@ -31,7 +31,7 @@ const unmock = new UnmockPackage(backend);
 let foo: IService;
 beforeAll(() => {
   unmock
-    .nock("https://www.foo.com", "foo")
+    .mock("https://www.foo.com", "foo")
     .get("/hello")
     .reply(200, { foo: "bar" }, { my: "header" })
     .post("/hello")

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -38,8 +38,13 @@ const DEFAULT_OPTIONS: IUnmockOptions = {
 
 export default class UnmockFaker implements IFaker {
   public createResponse: CreateResponse;
+
   /**
    * Add a new service to the faker using `nock` syntax.
+   */
+  public readonly mock: NockAPI;
+  /**
+   * Equivalent to `mock`, use that instead.
    */
   public readonly nock: NockAPI;
   public minItems: number;
@@ -67,6 +72,7 @@ export default class UnmockFaker implements IFaker {
     this.serviceStore = serviceStore;
     this.createResponse = this.createResponseCreator();
     this.nock = addFromNock(this.serviceStore);
+    this.mock = addFromNock(this.serviceStore);
   }
 
   /**

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -27,7 +27,12 @@ export class UnmockPackage implements IUnmockPackage {
    */
   public randomize: IBooleanSetting;
   public readonly backend: Backend;
+  /**
+   * Add a new service using declarative syntax.
+   */
+  public readonly mock: NockAPI;
   public readonly nock: NockAPI;
+
   private readonly opts: IUnmockOptions;
   private logger: ILogger = { log: () => undefined }; // Default logger does nothing
   constructor(
@@ -47,6 +52,7 @@ export class UnmockPackage implements IUnmockPackage {
       log: (message: string) => this.logger.log(message),
       randomize: () => this.randomize.get(),
     };
+    this.mock = addFromNock(this.backend.serviceStore);
     this.nock = addFromNock(this.backend.serviceStore);
   }
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -63,7 +63,7 @@ export class UnmockPackage implements IUnmockPackage {
    *
    * const faker = unmock.faker();
    * faker
-   *  .nock('https://api.github.com', 'github')
+   *  .mock('https://api.github.com', 'github')
    *  .get('/v1/users')
    *  .reply({ id: '1' });
    * const req: ISerializedRequest = {

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -103,7 +103,7 @@ export class ServiceStore {
    * @param nameOrHeaders Service name or the headers.
    * @param name Service name if the second argument was headers.
    */
-  public nock(
+  public mock(
     baseUrl: string,
     nameOrHeaders?:
       | string

--- a/packages/unmock-node/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-node/src/__tests__/dynamicService.test.ts
@@ -13,7 +13,7 @@ describe("Tests dynamic path tests", () => {
     it("Also handles multiple parameters", async () => {
       expect(nServices()).toEqual(0);
       unmock
-        .nock("https://www.foo.com", "foo")
+        .mock("https://www.foo.com", "foo")
         .get(["foo", ["baz", /\W+/], "bar", /\d+/, ["spam", /eggs/]])
         .reply(200);
       expect(nServices()).toEqual(1);
@@ -37,7 +37,7 @@ describe("Tests dynamic path tests", () => {
   describe("schema generates valid stuff", () => {
     it("faker works out of the box", async () => {
       unmock
-        .nock("https://www.foo.com")
+        .mock("https://www.foo.com")
         .get("/")
         .reply(200, u.string("date.future"));
       unmock.on();

--- a/packages/unmock-node/src/__tests__/spy-vs-spy.test.ts
+++ b/packages/unmock-node/src/__tests__/spy-vs-spy.test.ts
@@ -3,7 +3,7 @@ import { IService } from "unmock-core";
 import unmock from "../";
 
 unmock
-  .nock("https://www.foo.com", { reqheaders: { hello: "world" } }, "foo")
+  .mock("https://www.foo.com", { reqheaders: { hello: "world" } }, "foo")
   .get("/hello")
   .reply(200, { foo: "bar" }, { my: "header" })
   .post("/hello")

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -13,6 +13,6 @@ export const unmock = new UnmockPackage(new NodeBackend(), {
   logger: new WinstonLogger(),
 });
 
-export const nock = unmock.nock.bind(unmock);
-
+export const nock = unmock.mock.bind(unmock);
+export const mock = unmock.mock.bind(unmock);
 export default unmock;

--- a/packages/unmock-runner/src/__tests__/index.test.ts
+++ b/packages/unmock-runner/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import jestRunner from "../jestRunner";
 
 unmock
-  .nock("http://petstore.swagger.io", "petstore")
+  .mock("http://petstore.swagger.io", "petstore")
   .get("/v1/pets/54")
   .reply(200, { id: 10, name: "foo", tags: "bar" });
 

--- a/packages/unmock/README.md
+++ b/packages/unmock/README.md
@@ -66,7 +66,7 @@ const { runner, transform, u } = unmock;
 const { withCodes } = transform;
 
 unmock
-  .nock("https://zodiac.com", "zodiac")
+  .mock("https://zodiac.com", "zodiac")
   .get("/horoscope/{sign}") // 1
   .reply(200, {
     horoscope: u.string(), // 2
@@ -107,7 +107,7 @@ With unmock, you can (1) override a REST endpoint to provide (2) variable and (3
 The request hostname should be a string.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .get('/resource')
   .reply(200, u.integer())
 ```
@@ -115,7 +115,7 @@ unmock.nock('http://www.example.com')
 Unmock will then refer to the service as `example`. To specify the name of the service as `foo`, we would write.
 
 ```js
-unmock.nock('http://www.example.com', 'foo')
+unmock.mock('http://www.example.com', 'foo')
   .get('/resource')
   .reply(200, u.string())
 ```
@@ -131,7 +131,7 @@ unmock.default.associate('https://www2.example.com', 'foo')
 The request path should be a string, and you can use any [HTTP verb](#http-verbs). Wild-cards in the string should be enclosed in curly braces.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .get('/resource/{id}')
   .reply(200, u.string())
 ```
@@ -139,7 +139,7 @@ unmock.nock('http://www.example.com')
 Alternatively, you can use an array of path segments, where each segment is either a string, a string in curly-braces for an open parameter, or a key/value pair associating a name of a path parameter to a regex matching it.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .get(["users", /[0-9]+/, "status"]) // "/users/{id}/status"
   .reply(200, u.string())
 ```
@@ -151,7 +151,7 @@ You can specify the request body to be matched as the second argument to the `ge
 Here is an example of a post request that will only validate if it contains a token.
 
 ```js
-unmock.nock('http://www.example.com')
+unmock.mock('http://www.example.com')
   .post('/login', u.type({ token: u.string()}, {expires: u.integer()}))
   .reply(200, { id: u.string() })
 ```
@@ -167,7 +167,7 @@ Unmock automatically ignores query strings. However, it understands query string
 These parameters can be included as part of the path:
 
 ```js
-unmock.nock('http://example.com')
+unmock.mock('http://example.com')
   .get('/users?foo=bar')
   .reply(200)
 ```
@@ -175,7 +175,7 @@ unmock.nock('http://example.com')
 Instead of placing the entire URL, you can specify the query part as an object:
 
 ```js
-unmock.nock('http://example.com')
+unmock.mock('http://example.com')
   .get('/users')
   .query({ name:u.string(), surname: u.string() })
   .reply(200, { results: u.array({id: u.integer() }) })
@@ -186,7 +186,7 @@ unmock.nock('http://example.com')
 You can specify the request headers like this:
 
 ```js
-unmock.nock('http://www.example.com', {
+unmock.mock('http://www.example.com', {
   reqheaders: {
     authorization: 'Basic Auth',
   },
@@ -198,7 +198,7 @@ unmock.nock('http://www.example.com', {
 Or you can use a regular expression to check the header values.
 
 ```js
-const scope = nock('http://www.example.com', {
+unmock.mock('http://www.example.com', {
   reqheaders: {
     'X-My-Awesome-Header': /Awesome/i,
   },
@@ -214,7 +214,7 @@ Headers in unmock are always a partial match, meaning that additional headers ar
 You can specify the return status code for a path on the first argument of reply like this:
 
 ```js
-unmock.nock('http://myapp.iriscouch.com')
+unmock.mock('http://myapp.iriscouch.com')
   .get('/users/1')
   .reply(404)
 ```
@@ -222,7 +222,7 @@ unmock.nock('http://myapp.iriscouch.com')
 You can also specify the reply body as valid JSON, `json-schema-poet`, or any combination thereof.
 
 ```js
-unmock.nock('http://www.google.com')
+unmock.mock('http://www.google.com')
   .get('/')
   .reply(200, u.stringEnum(['Hello from Google!', 'Do no evil']))
 ```
@@ -230,7 +230,7 @@ unmock.nock('http://www.google.com')
 If you would like to transform any part of a constant reply (ie a fixture recorded from real API traffic) into a variable version of itself, use `u.fuzz`. This command infers the type of its input and produces output following the same schema.
 
 ```js
-unmock.nock('http://www.foo.com')
+unmock.mock('http://www.foo.com')
   .get('/')
   // produces { firstName: "a random string", lastName: "another random string" }
   .reply(200, u.fuzz({ firstName: "Bob", lastName: "Smith" }))
@@ -241,7 +241,7 @@ unmock.nock('http://www.foo.com')
 You can specify the reply headers like this:
 
 ```js
-unmock.nock('https://api.github.com')
+unmock.mock('https://api.github.com')
   .get('/repos/atom/atom/license')
   .reply(200, { license: 'MIT' }, { 'X-RateLimit-Remaining': u.integer() })
 ```
@@ -251,7 +251,7 @@ unmock.nock('https://api.github.com')
 You can chain behavior like this:
 
 ```js
-unmock. nock('http://myapp.iriscouch.com')
+unmock.mock('http://myapp.iriscouch.com')
   .get('/users/1')
   .reply(404)
   .post('/users', {
@@ -278,7 +278,7 @@ For ignorable API calls where you are passing through information but don't care
 
 ```js
 unmock
-  .nock("https://my-analytics-api.vendor.com)
+  .mock("https://my-analytics-api.vendor.com)
   .tldr();
 ```
 
@@ -386,7 +386,7 @@ To use the faker for mocking, you need to add services. The first option is to u
 
 ```ts
 faker
-  .nock("http://petstore.swagger.io", "petstore")
+  .mock("http://petstore.swagger.io", "petstore")
   .get("/v1/pets")
   .reply(200, { foo: u.string() });
 ```

--- a/packages/unmock/src/__tests__/end-to-end/readme/introductory-example.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/introductory-example.test.js
@@ -1,10 +1,10 @@
 const unmock = require("unmock");
-const { nock, transform, u } = unmock;
+const { mock, transform, u } = unmock;
 const { withCodes } = transform;
 const jestRunner = require("../../../../../unmock-runner/src/jestRunner")
   .default;
 
-nock("https://zodiac.com", "zodiac")
+mock("https://zodiac.com", "zodiac")
   .get("/horoscope/{sign}")
   .reply(200, {
     horoscope: u.string(),

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-hostname.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-hostname.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com")
+  .mock("http://www.example.com")
   .get("/resource")
   .reply(200, u.integer());
 

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-path-as-an-array.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-path-as-an-array.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com")
+  .mock("http://www.example.com")
   .get(["users", /[0-9]+/, "status"]) // "/users/{id}/status"
   .reply(200, { hello: u.string() });
 

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-path.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-path.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com")
+  .mock("http://www.example.com")
   .get("/resource/{id}")
   .reply(200, { hello: u.string() });
 

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-reply.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-reply.test.js
@@ -5,7 +5,7 @@ const jestRunner = require("../../../../../unmock-runner/src/jestRunner")
   .default;
 
 unmock
-  .nock("http://www.foo.com")
+  .mock("http://www.foo.com")
   .get("/")
   // produces { firstName: "a random string", lastName: "another random string" }
   .reply(200, u.fuzz({ firstName: "Bob", lastName: "Smith" }));

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-request-body.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-request-body.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com")
+  .mock("http://www.example.com")
   .post("/login", u.type({ token: u.string() }, { expires: u.integer() }))
   .reply(200, { id: u.string() });
 

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-request-headers.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-request-headers.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com", {
+  .mock("http://www.example.com", {
     reqheaders: {
       authorization: "Basic Auth",
     },

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-request-queries.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-request-queries.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com")
+  .mock("http://www.example.com")
   .get("/?foo=bar")
   .reply(200, { baz: u.string() })
   .get("/hello")

--- a/packages/unmock/src/__tests__/end-to-end/readme/using-alias.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/using-alias.test.js
@@ -2,7 +2,7 @@ const unmock = require("unmock");
 const { u } = unmock;
 
 unmock
-  .nock("http://www.example.com", "foo")
+  .mock("http://www.example.com", "foo")
   .get("/resource")
   .reply(200, u.integer());
 

--- a/packages/unmock/src/__tests__/end-to-end/simple-service-with-runner.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/simple-service-with-runner.test.ts
@@ -5,7 +5,7 @@ import jestRunner from "../../../../unmock-runner/src/jestRunner";
 const { responseBody } = transform;
 
 unmock
-  .nock("https://api.foo.com/v1", "foo")
+  .mock("https://api.foo.com/v1", "foo")
   .get("/users")
   .reply(
     200,

--- a/packages/unmock/src/__tests__/end-to-end/simple-service.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/simple-service.test.ts
@@ -4,7 +4,7 @@ import unmock, { Arr, transform, u } from "../../node";
 const { responseBody } = transform;
 
 unmock
-  .nock("https://api.foo.com/v1", "foo")
+  .mock("https://api.foo.com/v1", "foo")
   .get("/users")
   .reply(
     200,


### PR DESCRIPTION
- Adds `unmock.mock` as the preferred equivalent of `unmock.nock`
- Keeps `unmock.nock` for backwards compatibility

Why the change? Now that we're targeting environments beyond Node.js, users cannot be expected to be familiar with [nock](https://github.com/nock/nock). I also think it's better to make it clear that unmock-js is a standalone and independent library not designed as "nock alternative".

What do you think? @mikesol @carolstran 